### PR TITLE
libstagefright: Conditionally disable `thumbnail_block_model`

### DIFF
--- a/media/libstagefright/Android.bp
+++ b/media/libstagefright/Android.bp
@@ -371,7 +371,10 @@ cc_library {
         "-Werror",
         "-Wno-error=deprecated-declarations",
         "-Wno-multichar",
-    ],
+    ] + select(soong_config_variable("media", "target_uses_thumbnail_block_model"), {
+        "false": [],
+        default: ["-DUSE_BLOCK_MODEL"],
+    }),
 
     version_script: "exports.lds",
 

--- a/media/libstagefright/FrameDecoder.cpp
+++ b/media/libstagefright/FrameDecoder.cpp
@@ -872,7 +872,11 @@ sp<AMessage> VideoFrameDecoder::onGetFormatAndSeekOptions(
             || (mSeekMode == MediaSource::ReadOptions::SEEK_FRAME_INDEX);
     if (!isSeekingClosest) {
         if (mComponentName.startsWithIgnoreCase("c2.")) {
+#ifdef USE_BLOCK_MODEL
             mUseBlockModel = android::media::codec::provider_->thumbnail_block_model();
+#else
+            mUseBlockModel = false;
+#endif
         } else {
             // OMX Codec
             videoFormat->setInt32("android._num-input-buffers", 1);


### PR DESCRIPTION
Allow it to be disabled for devices that experience a mediaserver crash as follows after google enabled it in android 16:

06-25 01:14:11.195  1508 16500 F libc    : Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0 in tid 16500 (ALooper), pid 1508 (mediaserver64)
06-25 01:14:11.672 16513 16513 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
06-25 01:14:11.672 16513 16513 F DEBUG   : Build fingerprint: 'Sony/XQ-AS72/XQ-AS72:12/58.2.A.10.126/058002A010012603718185433:user/release-keys'
06-25 01:14:11.672 16513 16513 F DEBUG   : Revision: '0'
06-25 01:14:11.672 16513 16513 F DEBUG   : ABI: 'arm64'
06-25 01:14:11.672 16513 16513 F DEBUG   : Timestamp: 2025-06-25 01:14:11.262663301+0300
06-25 01:14:11.672 16513 16513 F DEBUG   : Process uptime: 1041s
06-25 01:14:11.672 16513 16513 F DEBUG   : Cmdline: /system/bin/mediaserver64
06-25 01:14:11.672 16513 16513 F DEBUG   : pid: 1508, tid: 16500, name: ALooper  >>> /system/bin/mediaserver64 <<<
06-25 01:14:11.672 16513 16513 F DEBUG   : uid: 1013
06-25 01:14:11.672 16513 16513 F DEBUG   : signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0000000000000000
06-25 01:14:11.672 16513 16513 F DEBUG   : Cause: null pointer dereference
06-25 01:14:11.672 16513 16513 F DEBUG   :     x0  0000007946e0ac40  x1  0000000001000000  x2  0000000000000008  x3  0000000000000000
06-25 01:14:11.672 16513 16513 F DEBUG   :     x4  722d666f726d6174  x5  0000000000000002  x6  0000000000000002  x7  0000000000000002
06-25 01:14:11.672 16513 16513 F DEBUG   :     x8  0000007946e0acd0  x9  0000000000000000  x10 0000000000000008  x11 00000000001fa400
06-25 01:14:11.672 16513 16513 F DEBUG   :     x12 0000000000000000  x13 0000007946e0ab94  x14 000000000007e900  x15 0000000000000002
06-25 01:14:11.672 16513 16513 F DEBUG   :     x16 00000079f2fc3690  x17 00000079f2a849e0  x18 0000007946830000  x19 b4000079f6c7f180
06-25 01:14:11.672 16513 16513 F DEBUG   :     x20 0000000000000000  x21 0000000000000000  x22 b400007950c0a980  x23 7f3e854abf63ac30
06-25 01:14:11.673 16513 16513 F DEBUG   :     x24 0000000000000001  x25 0000000000000000  x26 0000007946e0b3c0  x27 00000079f2fb9878
06-25 01:14:11.673 16513 16513 F DEBUG   :     x28 00000079f2fb8f48  x29 0000007946e0ad30
06-25 01:14:11.673 16513 16513 F DEBUG   :     lr  00000079f2eb31a0  sp  0000007946e0ac10  pc  00000079f2eb31a4  pst 0000000060001000
06-25 01:14:11.673 16513 16513 F DEBUG   : 9 total frames
06-25 01:14:11.673 16513 16513 F DEBUG   : backtrace:
06-25 01:14:11.673 16513 16513 F DEBUG   :       #00 pc 00000000000f61a4  /system/lib64/libstagefright.so (android::FrameDecoder::handleOutputBufferAsync(int, long)+1268) (BuildId: ab3f1c8f0368f98174bb702a4d9fd361)
06-25 01:14:11.673 16513 16513 F DEBUG   :       #01 pc 00000000000f59f8  /system/lib64/libstagefright.so (android::AsyncCodecHandler::onMessageReceived(android::sp<android::AMessage> const&)+1032) (BuildId: ab3f1c8f0368f98174bb702a4d9fd361)
06-25 01:14:11.673 16513 16513 F DEBUG   :       #02 pc 000000000001b708  /system/lib64/libstagefright_foundation.so (android::AHandler::deliverMessage(android::sp<android::AMessage> const&)+152) (BuildId: fd05a7c4a35f22c272bab42d96244ba4)
06-25 01:14:11.673 16513 16513 F DEBUG   :       #03 pc 0000000000022a5c  /system/lib64/libstagefright_foundation.so (android::AMessage::deliver()+172) (BuildId: fd05a7c4a35f22c272bab42d96244ba4)
06-25 01:14:11.673 16513 16513 F DEBUG   :       #04 pc 000000000001cc68  /system/lib64/libstagefright_foundation.so (android::ALooper::loop()+536) (BuildId: fd05a7c4a35f22c272bab42d96244ba4)
06-25 01:14:11.673 16513 16513 F DEBUG   :       #05 pc 0000000000017e58  /system/lib64/libutils.so (android::Thread::_threadLoop(void*)+248) (BuildId: 9ab654370e3df2f5412f0469bc7c934c)
06-25 01:14:11.673 16513 16513 F DEBUG   :       #06 pc 0000000000019d44  /system/lib64/libutils.so (libutil_thread_trampoline(void*) (.__uniq.226528677032898775202282855395389835431)+20) (BuildId: 9ab654370e3df2f5412f0469bc7c934c)
06-25 01:14:11.673 16513 16513 F DEBUG   :       #07 pc 00000000000da3ac  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+236) (BuildId: 1ff6cb6d00073ea33e11702ebb45fcb4)
06-25 01:14:11.673 16513 16513 F DEBUG   :       #08 pc 00000000000cb2b0  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 1ff6cb6d00073ea33e11702ebb45fcb4)