### PR TITLE
codec2: Conditionally Revert "MultiAccessUnit reflector helper alloca…

### DIFF
--- a/media/codec2/hal/aidl/Android.bp
+++ b/media/codec2/hal/aidl/Android.bp
@@ -139,7 +139,10 @@ cc_library {
 
     cflags: [
         "-DNO_C2_INPUT_SURFACE",
-    ],
+    ] + select(soong_config_variable("codec2", "target_ships_dolby"), {
+        any @ value: ["-DTARGET_SHIPS_DOLBY"],
+        default: [],
+    }),
 }
 
 // DO NOT DEPEND ON THIS DIRECTLY
@@ -232,6 +235,11 @@ cc_library {
         "libstagefright_bufferpool@2.0.1",
         "libui",
     ],
+
+    cflags: [] + select(soong_config_variable("codec2", "target_ships_dolby"), {
+        any @ value: ["-DTARGET_SHIPS_DOLBY"],
+        default: [],
+    }),
 }
 
 // public dependency for Codec 2.0 HAL service implementations

--- a/media/codec2/hal/aidl/ComponentStore.cpp
+++ b/media/codec2/hal/aidl/ComponentStore.cpp
@@ -156,6 +156,7 @@ ComponentStore::ComponentStore(const std::shared_ptr<C2ComponentStore>& store)
         mParamReflectors.push_back(paramReflector);
     }
 #endif
+#ifndef TARGET_SHIPS_DOLBY
     // MultiAccessUnit reflector helper is allocated once per store.
     // All components in this store can reuse this reflector helper.
     if (MultiAccessUnitHelper::isEnabledOnPlatform()) {
@@ -163,6 +164,7 @@ ComponentStore::ComponentStore(const std::shared_ptr<C2ComponentStore>& store)
         mParamReflectors.push_back(helper);
         mMultiAccessUnitReflector = helper;
     }
+#endif
 
     // Retrieve supported parameters from store
     using namespace std::placeholders;
@@ -253,7 +255,12 @@ std::shared_ptr<MultiAccessUnitInterface> ComponentStore::tryCreateMultiAccessUn
                 std::shared_ptr<C2ReflectorHelper> multiAccessReflector(new C2ReflectorHelper());
                 multiAccessUnitIntf = std::make_shared<MultiAccessUnitInterface>(
                         c2interface,
+#ifndef TARGET_SHIPS_DOLBY
                         mMultiAccessUnitReflector);
+#else
+                        multiAccessReflector);
+                mParamReflectors.push_back(multiAccessReflector);
+#endif
             }
         }
     }

--- a/media/codec2/hal/aidl/include/codec2/aidl/ComponentStore.h
+++ b/media/codec2/hal/aidl/include/codec2/aidl/ComponentStore.h
@@ -127,8 +127,10 @@ protected:
     std::shared_ptr<C2ComponentStore> mStore;
     std::vector<std::shared_ptr<C2ParamReflector>> mParamReflectors;
 
+#ifndef TARGET_SHIPS_DOLBY
     // Reflector helper for MultiAccessUnitHelper
     std::shared_ptr<C2ReflectorHelper> mMultiAccessUnitReflector;
+#endif
 
     std::map<C2Param::CoreIndex, std::shared_ptr<C2StructDescriptor>> mStructDescriptors;
     std::set<C2Param::CoreIndex> mUnsupportedStructDescriptors;

--- a/media/codec2/hal/hidl/1.0/utils/Android.bp
+++ b/media/codec2/hal/hidl/1.0/utils/Android.bp
@@ -131,6 +131,11 @@ cc_library {
         "libstagefright_bufferpool@2.0.1",
         "libui",
     ],
+
+    cflags: [] + select(soong_config_variable("codec2", "target_ships_dolby"), {
+        any @ value: ["-DTARGET_SHIPS_DOLBY"],
+        default: [],
+    }),
 }
 
 // public dependency for Codec 2.0 HAL service implementations

--- a/media/codec2/hal/hidl/1.0/utils/ComponentStore.cpp
+++ b/media/codec2/hal/hidl/1.0/utils/ComponentStore.cpp
@@ -146,6 +146,7 @@ ComponentStore::ComponentStore(const std::shared_ptr<C2ComponentStore>& store)
     }
 #endif
 
+#ifndef TARGET_SHIPS_DOLBY
     // MultiAccessUnit reflector helper is allocated once per store.
     // All components in this store can reuse this reflector helper.
     if (MultiAccessUnitHelper::isEnabledOnPlatform()) {
@@ -153,6 +154,7 @@ ComponentStore::ComponentStore(const std::shared_ptr<C2ComponentStore>& store)
         mParamReflectors.push_back(helper);
         mMultiAccessUnitReflector = helper;
     }
+#endif
 
     // Retrieve supported parameters from store
     using namespace std::placeholders;
@@ -239,7 +241,12 @@ std::shared_ptr<MultiAccessUnitInterface> ComponentStore::tryCreateMultiAccessUn
                 std::shared_ptr<C2ReflectorHelper> multiAccessReflector(new C2ReflectorHelper());
                 multiAccessUnitIntf = std::make_shared<MultiAccessUnitInterface>(
                         c2interface,
+#ifndef TARGET_SHIPS_DOLBY
                         mMultiAccessUnitReflector);
+#else
+                        multiAccessReflector);
+                mParamReflectors.push_back(multiAccessReflector);
+#endif
             }
         }
     }

--- a/media/codec2/hal/hidl/1.0/utils/include/codec2/hidl/1.0/ComponentStore.h
+++ b/media/codec2/hal/hidl/1.0/utils/include/codec2/hidl/1.0/ComponentStore.h
@@ -131,8 +131,10 @@ protected:
     std::shared_ptr<C2ComponentStore> mStore;
     std::vector<std::shared_ptr<C2ParamReflector>> mParamReflectors;
 
+#ifndef TARGET_SHIPS_DOLBY
     // Reflector helper for MultiAccessUnitHelper
     std::shared_ptr<C2ReflectorHelper> mMultiAccessUnitReflector;
+#endif
 
     std::map<C2Param::CoreIndex, std::shared_ptr<C2StructDescriptor>> mStructDescriptors;
     std::set<C2Param::CoreIndex> mUnsupportedStructDescriptors;

--- a/media/codec2/hal/hidl/1.1/utils/Android.bp
+++ b/media/codec2/hal/hidl/1.1/utils/Android.bp
@@ -136,6 +136,11 @@ cc_library {
         "libstagefright_bufferpool@2.0.1",
         "libui",
     ],
+
+    cflags: [] + select(soong_config_variable("codec2", "target_ships_dolby"), {
+        any @ value: ["-DTARGET_SHIPS_DOLBY"],
+        default: [],
+    }),
 }
 
 // public dependency for Codec 2.0 HAL service implementations

--- a/media/codec2/hal/hidl/1.1/utils/ComponentStore.cpp
+++ b/media/codec2/hal/hidl/1.1/utils/ComponentStore.cpp
@@ -146,6 +146,7 @@ ComponentStore::ComponentStore(const std::shared_ptr<C2ComponentStore>& store)
     }
 #endif
 
+#ifndef TARGET_SHIPS_DOLBY
     // MultiAccessUnit reflector helper is allocated once per store.
     // All components in this store can reuse this reflector helper.
     if (MultiAccessUnitHelper::isEnabledOnPlatform()) {
@@ -153,6 +154,7 @@ ComponentStore::ComponentStore(const std::shared_ptr<C2ComponentStore>& store)
         mParamReflectors.push_back(helper);
         mMultiAccessUnitReflector = helper;
     }
+#endif
 
     // Retrieve supported parameters from store
     using namespace std::placeholders;
@@ -239,7 +241,12 @@ std::shared_ptr<MultiAccessUnitInterface> ComponentStore::tryCreateMultiAccessUn
                 std::shared_ptr<C2ReflectorHelper> multiAccessReflector(new C2ReflectorHelper());
                 multiAccessUnitIntf = std::make_shared<MultiAccessUnitInterface>(
                         c2interface,
+#ifndef TARGET_SHIPS_DOLBY
                         mMultiAccessUnitReflector);
+#else
+                        multiAccessReflector);
+                mParamReflectors.push_back(multiAccessReflector);
+#endif
             }
         }
     }

--- a/media/codec2/hal/hidl/1.1/utils/include/codec2/hidl/1.1/ComponentStore.h
+++ b/media/codec2/hal/hidl/1.1/utils/include/codec2/hidl/1.1/ComponentStore.h
@@ -139,8 +139,10 @@ protected:
     std::shared_ptr<C2ComponentStore> mStore;
     std::vector<std::shared_ptr<C2ParamReflector>> mParamReflectors;
 
+#ifndef TARGET_SHIPS_DOLBY
     // Reflector helper for MultiAccessUnitHelper
     std::shared_ptr<C2ReflectorHelper> mMultiAccessUnitReflector;
+#endif
 
     std::map<C2Param::CoreIndex, std::shared_ptr<C2StructDescriptor>> mStructDescriptors;
     std::set<C2Param::CoreIndex> mUnsupportedStructDescriptors;

--- a/media/codec2/hal/hidl/1.2/utils/Android.bp
+++ b/media/codec2/hal/hidl/1.2/utils/Android.bp
@@ -145,6 +145,11 @@ cc_library {
         "libstagefright_bufferpool@2.0.1",
         "libui",
     ],
+
+    cflags: [] + select(soong_config_variable("codec2", "target_ships_dolby"), {
+        any @ value: ["-DTARGET_SHIPS_DOLBY"],
+        default: [],
+    }),
 }
 
 // public dependency for Codec 2.0 HAL service implementations

--- a/media/codec2/hal/hidl/1.2/utils/ComponentStore.cpp
+++ b/media/codec2/hal/hidl/1.2/utils/ComponentStore.cpp
@@ -146,6 +146,7 @@ ComponentStore::ComponentStore(const std::shared_ptr<C2ComponentStore>& store)
     }
 #endif
 
+#ifndef TARGET_SHIPS_DOLBY
     // MultiAccessUnit reflector helper is allocated once per store.
     // All components in this store can reuse this reflector helper.
     if (MultiAccessUnitHelper::isEnabledOnPlatform()) {
@@ -153,6 +154,7 @@ ComponentStore::ComponentStore(const std::shared_ptr<C2ComponentStore>& store)
         mParamReflectors.push_back(helper);
         mMultiAccessUnitReflector = helper;
     }
+#endif
 
     // Retrieve supported parameters from store
     using namespace std::placeholders;
@@ -239,7 +241,12 @@ std::shared_ptr<MultiAccessUnitInterface> ComponentStore::tryCreateMultiAccessUn
                 std::shared_ptr<C2ReflectorHelper> multiAccessReflector(new C2ReflectorHelper());
                 multiAccessUnitIntf = std::make_shared<MultiAccessUnitInterface>(
                         c2interface,
+#ifndef TARGET_SHIPS_DOLBY
                         mMultiAccessUnitReflector);
+#else
+                        multiAccessReflector);
+                mParamReflectors.push_back(multiAccessReflector);
+#endif
             }
         }
     }

--- a/media/codec2/hal/hidl/1.2/utils/include/codec2/hidl/1.2/ComponentStore.h
+++ b/media/codec2/hal/hidl/1.2/utils/include/codec2/hidl/1.2/ComponentStore.h
@@ -146,8 +146,10 @@ protected:
     std::shared_ptr<C2ComponentStore> mStore;
     std::vector<std::shared_ptr<C2ParamReflector>> mParamReflectors;
 
+#ifndef TARGET_SHIPS_DOLBY
     // Reflector helper for MultiAccessUnitHelper
     std::shared_ptr<C2ReflectorHelper> mMultiAccessUnitReflector;
+#endif
 
     std::map<C2Param::CoreIndex, std::shared_ptr<C2StructDescriptor>> mStructDescriptors;
     std::set<C2Param::CoreIndex> mUnsupportedStructDescriptors;


### PR DESCRIPTION
…ted once per ComponentStore"

* Fixes Dolby decoders crashing.

* Original Commit: https://github.com/VoltageOS/frameworks_av/commit/a079a8161156ac521adbf97c2441c961deee9cd3