### PR TITLE
camera: bypass `isSensorPixelModeConsistent` check for priv-app camer…

### DIFF
--- a/services/camera/libcameraservice/Android.bp
+++ b/services/camera/libcameraservice/Android.bp
@@ -247,6 +247,9 @@ cc_library {
     ] + select(soong_config_variable("cameraservice", "disable_torch_control"), {
         any @ value: ["-DDISABLE_TORCH_CONTROL"],
         default: [],
+    }) + select(soong_config_variable("cameraservice", "bypass_pixelmode"), {
+        any @ value: ["-DBYPASS_PIXELMODE"],
+        default: [],
     }),
 }
 

--- a/services/camera/libcameraservice/api2/CameraDeviceClient.cpp
+++ b/services/camera/libcameraservice/api2/CameraDeviceClient.cpp
@@ -614,7 +614,11 @@ binder::Status CameraDeviceClient::submitRequestList(
             if (streamIdSetIt != mHighResolutionCameraIdToStreamIdSet.end()) {
                 std::list<int> streamIdsUsedInRequest = getIntersection(streamIdSetIt->second,
                         outputStreamIds);
+#ifndef BYPASS_PIXELMODE
                 if (!request.mIsReprocess &&
+#else
+                if (!request.mIsReprocess && !mPrivilegedClient &&
+#endif
                         !isSensorPixelModeConsistent(streamIdsUsedInRequest, it.settings)) {
                      ALOGE("%s: Camera %s: Request settings CONTROL_SENSOR_PIXEL_MODE not "
                             "consistent with configured streams. Rejecting request.",


### PR DESCRIPTION
…a apps

Resolves the following error on NubiaCamera

E CameraDeviceClient: submitRequestList: Camera 1: Request settings CONTROL_SENSOR_PIXEL_MODE not consistent with configured streams. Rejecting request.

Change-Id: I6f8fe61dbe0af8ca80acd7c32de14179bf03ff23